### PR TITLE
support an existing PVC for the data volume

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fcrepo
 description: Fedora Commons Repository 4
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: 4.7.5
 dependencies:
   - name: postgresql

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,8 +30,15 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: data
+          {{- if and .Values.storage.enabled .Values.storage.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.existingClaim }}
+          {{- else if .Values.storage.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "fcrepo.fullname" . }}
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
       initContainers:
         - name: "remove-lost-found"
           image: "busybox:1.32.0"

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if and .Values.storage.enabled (not .Values.storage.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -18,3 +19,4 @@ spec:
   {{- if .Values.storage.className }}
   storageClassName: "{{ .Values.storage.className }}"
   {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,9 @@
 replicaCount: 1
 
 storage: {}
+  # enabled: true
+  # size: 5.5Ti
+  # existingClaim: optionalExistingClaimName
 
 image:
   repository: samvera/fcrepo4


### PR DESCRIPTION
allow reuse of an existing PVC for the data volume; also allow skipping persistence provisioning (this is useful for throw-away deployments).