### PR TITLE
Use ghcr.io for samvera/fcrepo4 image

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 storage: {}
 
 image:
-  repository: samvera/fcrepo4
+  repository: ghcr.io/samvera/fcrepo4
   pullPolicy: IfNotPresent
   tag: 4.7.5
 


### PR DESCRIPTION
Docker Hub was still being used for the fcrepo4 image, and it has not been updated with a cgroupsv2 fix. This uses the already available updated image from our ghcr.io repository.