### PR TITLE
Bump chart to 1.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: fcrepo
 description: Fedora Commons Repository 4
 type: application
-version: 0.8.1
+version: 1.0.0
 appVersion: 4.7.5
 dependencies:
   - name: postgresql
-    version: 9.3.3
-    repository: https://charts.bitnami.com/bitnami
+    version: 11.6.12
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ maintained with that environment.
 
 In this case, `fcrepo` should be deployed with postgresql explictly disabled, but
 externalPostgresql.host or global.postgresql.postgresqlHost set to your upstream value.
-externalPostgresql.password and externalPostgresql.username or global.postgresql.postgresqlPassword
-and global.postgresql.postgresqlUsername can be used as needed depending on your set up. If both
-externalPostgresql.password and globa.postgresql.postgresqlPassword are set, then
+externalPostgresql.password and externalPostgresql.username or `global.postgresql.auth.password`
+and `global.postgresql.auth.username` can be used as needed depending on your set up. If both
+externalPostgresql.password and `global.postgresql.auth.password` are set, then
 externalPostgresql.password is used as an override.
 This is usually done in the context of a parent chart which provides the postgresql instance, for example:
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -86,10 +86,10 @@ Return PostgreSQL username
 {{- define "fcrepo.postgresql.username" }}
 {{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.username }}
     {{- .Values.externalPostgresql.username }}
-{{- else if and (not .Values.postgresql.enabled) .Values.global.postgresql.postgresqlUsername }}
-    {{- .Values.global.postgresql.postgresqlUsername }}
+{{- else if and (not .Values.postgresql.enabled) .Values.global.postgresql.auth.username }}
+    {{- .Values.global.postgresql.auth.username }}
 {{- else }}
-    {{- .Values.postgresql.postgresqlUsername }}
+    {{- .Values.postgresql.auth.username }}
 {{- end }}
 {{- end }}
 
@@ -99,10 +99,10 @@ Return PostgreSQL password
 {{- define "fcrepo.postgresql.password" }}
 {{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.password }}
     {{- .Values.externalPostgresql.password }}
-{{- else if and (not .Values.postgresql.enabled) .Values.global.postgresql.postgresqlPassword }}
-    {{- .Values.global.postgresql.postgresqlPassword }}
+{{- else if and (not .Values.postgresql.enabled) .Values.global.postgresql.auth.password }}
+    {{- .Values.global.postgresql.auth.password }}
 {{- else }}
-    {{- .Values.postgresql.postgresqlPassword }}
+    {{- .Values.postgresql.auth.password }}
 {{- end }}
 {{- end }}
 

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -8,6 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase }}
+  DATABASE_NAME: {{ .Values.postgresql.auth.database }}
   DATABASE_USER: {{ include "fcrepo.postgresql.username" . }}
   DATABASE_HOST: {{ include "fcrepo.postgresql.host" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,10 +65,11 @@ postgresql:
   enabled: true
   image:
     repository: bitnami/postgresql
-    tag: 12.3.0
-  postgresqlUsername: fcrepo
-  postgresqlPassword: fcrepo_pass
-  postgresqlDatabase: fcrepo
+    tag: 12.11.0-debian-11-r12
+  auth:
+    username: fcrepo
+    password: fcrepo_pass
+    database: fcrepo
   servicePort: 5432
 
 externalPostgresql: {}


### PR DESCRIPTION
- Upgrade the postgresql chart dependency to the latest version.
- Update configuration as needed for `_helpers`, `ConfigMap`, and
  `Secret`
- KEEP the postgresql tag as `12.x` due to an error that shows on later
  versions in configuring auth in the Fedora image: `The authentication
  type 10 is not supported`. We were not sure which, if any, of the [issues/fixes suggested here may be in play](https://stackoverflow.com/questions/64210167/unable-to-connect-to-postgres-db-due-to-the-authentication-type-10-is-not-suppor) for the issue. But, sticking to `12.x` keeps the chart working.

Co-authored-by: Kristian De Castro <okaykris13@yahoo.com>